### PR TITLE
feat: Playwright Video & Attach to Allure Report

### DIFF
--- a/packages/codeceptjs-configure/lib/config/drivers/playwright.conf.js
+++ b/packages/codeceptjs-configure/lib/config/drivers/playwright.conf.js
@@ -7,6 +7,7 @@ const host = require('../../host/host');
 const { devices } = require('playwright');
 const GOOGLE_CHROME = 'google:chrome';
 const CHROMIUM = 'chromium';
+const { env } = require('process');
 
 const getPlaywrightBrowser = function () {
     if (BROWSER && BROWSER.match('playwright:[a-zA-Z]')) {
@@ -63,9 +64,10 @@ const playwright_conf = function () {
                 url: host.get(),
                 waitForNavigation: 'domcontentloaded',
                 show: process.env.HEADLESS === 'false',
-                waitForTimeout: (process.env.BROWSER_WAIT_TIMEOUT_IN_SECONDS || 15) * 1000,
+                waitForTimeout: (env.BROWSER_WAIT_TIMEOUT_IN_SECONDS || 15) * 1000,
                 restart: true,
-                video: process.env.RECORD_VIDEO_ON_FAIL === 'true',
+                video: env.RECORD_VIDEO_ON_FAIL === 'true' || env.RECORD_PLAYWRIGHT_VIDEO === 'true',
+                keepVideoForPassedTests: env.RECORD_PLAYWRIGHT_VIDEO === 'true',
                 trace: process.env.RECORD_TRACE_ON_FAIL === 'true',
                 fullPageScreenshots: true,
                 emulate: {

--- a/packages/codeceptjs-configure/lib/config/drivers/playwright.conf.js
+++ b/packages/codeceptjs-configure/lib/config/drivers/playwright.conf.js
@@ -68,7 +68,7 @@ const playwright_conf = function () {
                 restart: true,
                 video: env.RECORD_VIDEO_ON_FAIL === 'true' || env.RECORD_PLAYWRIGHT_VIDEO === 'true',
                 keepVideoForPassedTests: env.RECORD_PLAYWRIGHT_VIDEO === 'true',
-                trace: process.env.RECORD_TRACE_ON_FAIL === 'true',
+                trace: env.RECORD_TRACE_ON_FAIL === 'true',
                 fullPageScreenshots: true,
                 emulate: {
                     ignoreHTTPSErrors: true,

--- a/packages/codeceptjs-configure/lib/helpers/playwright.helper.js
+++ b/packages/codeceptjs-configure/lib/helpers/playwright.helper.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const Helper = require('@codeceptjs/helper');
+
+/**
+ * Helper class for the Playwright Report
+ */
+class PlaywrightHelper extends Helper {
+    /**
+     * Constructor
+     *
+     * @param config
+     */
+    constructor(config) {
+        super(config);
+    }
+
+    /**
+     * Attach Video to Allure Report
+     * @param test
+     */
+    async _attachVideo(test) {
+        const Playwright = codeceptjs.container.helpers('Playwright');
+        if (Playwright) {
+            await Playwright.browserContext.close();
+            const allure = codeceptjs.container.plugins('allure');
+            const FORMAT = 'video/webm';
+            const TITLE = 'Execution Video';
+            const video = test.artifacts?.video || test._retriedTest?.artifacts?.video;
+            if (video) {
+                codeceptjs.output.print(`Attaching Video: ${video}`);
+                allure.addAttachment(TITLE, fs.readFileSync(video), FORMAT);
+            }
+        }
+    }
+
+    /**
+     * Event when Test Failed
+     *
+     * @param test
+     */
+    async _failed(test) {
+        await this._attachVideo(test);
+    }
+
+    /**
+     * Event when Test Passed
+     *
+     * @param test
+     */
+    async _passed(test) {
+        await this._attachVideo(test);
+    }
+}
+
+module.exports = PlaywrightHelper;

--- a/website/docs/03-03-playwright/1-run-with-playwright.md
+++ b/website/docs/03-03-playwright/1-run-with-playwright.md
@@ -95,13 +95,17 @@ I.usePlaywrightTo('trigger method on component', async ({ page }) => {
 });
 ```
 
-### Record Playwright Video on FAIL
+### Record Playwright Video and Attach on Allure Report
 
 To enable this feature, add the below ENV property to the `codecept.env` file,
 
 ```js
-RECORD_VIDEO_ON_FAIL = true;
+RECORD_VIDEO_ON_FAIL = true; // only to record video on Fail & attach to Allure
 ```
+
+````js
+RECORD_PLAYWRIGHT_VIDEO = true; // record and attach Playwright video regardless of results
+
 
 ### Record Playwright Trace on FAIL
 
@@ -109,6 +113,6 @@ To enable this feature, add the below ENV property to the `codecept.env` file,
 
 ```js
 RECORD_TRACE_ON_FAIL = true;
-```
+````
 
 More info trace: https://codecept.io/playwright/#trace


### PR DESCRIPTION

### Record Playwright Video and Attach on Allure Report

To enable this feature, add the below ENV property to the `codecept.env` file,

```js
RECORD_VIDEO_ON_FAIL = true; // only to record video on Fail & attach to Allure
```

````js
RECORD_PLAYWRIGHT_VIDEO = true; // record and attach Playwright video regardless of results


### Record Playwright Trace on FAIL

To enable this feature, add the below ENV property to the `codecept.env` file,

```js
RECORD_TRACE_ON_FAIL = true;
````

More info trace: https://codecept.io/playwright/#trace
