### PR TITLE
add Shadow DOM Support default thru CLI

### DIFF
--- a/packages/create-codeceptjs-bdd-tests/acceptance/plugins/shadow-dom.plugin.js
+++ b/packages/create-codeceptjs-bdd-tests/acceptance/plugins/shadow-dom.plugin.js
@@ -1,0 +1,14 @@
+/* eslint @typescript-eslint/no-var-requires: "off" */
+const codeceptjs = require('codeceptjs');
+
+/**
+ * Custom Locators
+ */
+module.exports = function () {
+    codeceptjs.locator.addFilter((providedLocator, locatorObj) => {
+        // eslint-disable-next-line no-undef
+        if (typeof providedLocator === 'string' && process.env.DRIVER.toLowerCase() === 'webdriver') {
+            locatorObj.type = 'shadowDom';
+        }
+    });
+};

--- a/packages/create-codeceptjs-bdd-tests/cli/ask.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/ask.js
@@ -12,8 +12,7 @@ exports.aboutProjectPaths = () => {
             name: 'ROOT_PATH',
             type: 'input',
             default: process.cwd(),
-            message:
-                "Enter the Full PATH to your Project's source-code location (full path to /package.json): ",
+            message: "Enter the Full PATH to your Project's source-code location (full path to /package.json): ",
         },
         {
             name: 'RELATIVE_PATH',
@@ -30,6 +29,16 @@ exports.aboutSauceLabs = () => {
             name: 'INTEGRATE_SAUCE_LABS',
             type: 'confirm',
             message: 'Do you want to integrate SauceLabs?',
+        },
+    ]);
+};
+
+exports.enableShadowDomSupport = () => {
+    return inquirer.prompt([
+        {
+            name: 'ENABLE_SHADOW_DOM_SUPPORT',
+            type: 'confirm',
+            message: 'Do you want to enable the Shadow DOM support for Webdriver runs?',
         },
     ]);
 };

--- a/packages/create-codeceptjs-bdd-tests/cli/create.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/create.js
@@ -6,6 +6,7 @@ const shell = require('shelljs');
 const path = require('path');
 const fs = require('fs');
 const UpdateEnvironments = require('./update.env');
+const ShadowDomSupport = require('./shadowdom.support');
 
 const { addNpmScripts, installDependencies } = require('./update.package');
 const log = require('./logger');
@@ -15,6 +16,7 @@ const {
     aboutDriver,
     aboutScenarioExecutions,
     aboutSauceLabsAccount,
+    enableShadowDomSupport,
 } = require('./ask');
 
 const run = async () => {
@@ -36,6 +38,14 @@ const run = async () => {
      * update driver
      **********************************************/
     const updateDriver = async () => {
+        const { ENABLE_SHADOW_DOM_SUPPORT } = await enableShadowDomSupport();
+
+        if (ENABLE_SHADOW_DOM_SUPPORT) {
+            new ShadowDomSupport({
+                rootPath: ROOT_PATH,
+                relativePath: RELATIVE_PATH,
+            });
+        }
         if (DRIVER === 'WebDriver') {
             const { INTEGRATE_SAUCE_LABS } = await aboutSauceLabs();
 

--- a/packages/create-codeceptjs-bdd-tests/cli/create.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/create.js
@@ -38,6 +38,8 @@ const run = async () => {
      * update driver
      **********************************************/
     const updateDriver = async () => {
+        log.shadowDomInfo();
+
         const { ENABLE_SHADOW_DOM_SUPPORT } = await enableShadowDomSupport();
 
         if (ENABLE_SHADOW_DOM_SUPPORT) {

--- a/packages/create-codeceptjs-bdd-tests/cli/logger.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/logger.js
@@ -93,7 +93,8 @@ const shadowDomInfo = () => {
         '\n' +
             chalk.bold.blue(
                 emoji.emojify(':new_moon_with_face:') +
-                    ' Add Shadow DOM exclusive support for the Webdriver run. Ease to automated Salesforce apps. '
+                    ' Add Shadow DOM exclusive support for the Webdriver run. Adds Webdriver parity with Playwright. Ease to automate Salesforce apps.' +
+                    emoji.emojify(':cyclone:')
             )
     );
 };

--- a/packages/create-codeceptjs-bdd-tests/cli/logger.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/logger.js
@@ -80,11 +80,21 @@ const infoAboutPaths = (path) => {
     );
 };
 
-const saucelabsInfo = (username, key) => {
+const saucelabsInfo = () => {
     cli.default.log(
         '\n' +
             chalk.bold.red(emoji.emojify(':bulb:') + ' You can run tests on Saucelabs thru a "--profile" flag: ') +
             chalk.bold.bgBlue('yarn acceptance --profile sauce:chrome')
+    );
+};
+
+const shadowDomInfo = () => {
+    cli.default.log(
+        '\n' +
+            chalk.bold.blue(
+                emoji.emojify(':new_moon_with_face:') +
+                    ' Add Shadow DOM exclusive support for the Webdriver run. Ease to automated Salesforce apps. '
+            )
     );
 };
 
@@ -138,4 +148,5 @@ module.exports = {
     scenarioExecutions,
     tipsToExecuteOnDriver,
     infoAboutPaths,
+    shadowDomInfo,
 };

--- a/packages/create-codeceptjs-bdd-tests/cli/shadowdom.support.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/shadowdom.support.js
@@ -23,8 +23,6 @@ class ShadowDomSupport {
 
         const codeceptEnvFile = path.join(envs.rootPath, envs.relativePath, `acceptance`, 'config', 'codecept.env');
 
-        console.log('\n\n\n\n\n\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>' + codeceptEnvFile);
-
         fs.appendFileSync(codeceptEnvFile, '\n\n# SHADOW DOM SUPPORT');
         fs.appendFileSync(codeceptEnvFile, '\nENABLE_SHADOW_DOM_SUPPORT = true');
         fs.appendFileSync(codeceptEnvFile, '\nCUSTOM_LOCATOR_STRATEGY = true');

--- a/packages/create-codeceptjs-bdd-tests/cli/shadowdom.support.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/shadowdom.support.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+class ShadowDomSupport {
+    constructor(envs) {
+        const shadowDomPlugin = path.join(
+            envs.rootPath,
+            envs.relativePath,
+            `acceptance`,
+            'plugins',
+            'shadow-dom.plugin.js'
+        );
+
+        const destinationPath = path.join(
+            envs.rootPath,
+            envs.relativePath,
+            `acceptance`,
+            'plugins',
+            'shadow-dom.plugin.js'
+        );
+
+        fs.copyFileSync(shadowDomPlugin, destinationPath);
+
+        const codeceptEnvFile = path.join(envs.rootPath, envs.relativePath, `acceptance`, 'config', 'codecept.env');
+
+        console.log('\n\n\n\n\n\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>' + codeceptEnvFile);
+
+        fs.appendFileSync(codeceptEnvFile, '\n\n# SHADOW DOM SUPPORT');
+        fs.appendFileSync(codeceptEnvFile, '\nENABLE_SHADOW_DOM_SUPPORT = true');
+        fs.appendFileSync(codeceptEnvFile, '\nCUSTOM_LOCATOR_STRATEGY = true');
+        fs.appendFileSync(codeceptEnvFile, '\nCUSTOM_LOCATOR_STRATEGY_NAME = shadowDom\n');
+    }
+}
+
+module.exports = ShadowDomSupport;

--- a/packages/create-codeceptjs-bdd-tests/codecept.conf.js
+++ b/packages/create-codeceptjs-bdd-tests/codecept.conf.js
@@ -20,14 +20,17 @@ let conf = {
     },
 
     helpers: {
-        driver_helper: {
-            require: './acceptance/helpers/driver.helper',
-        },
         PlaywrightHelper: {
             require: 'codeceptjs-configure/lib/helpers/playwright.helper.js',
         },
     },
 
+    plugins: {
+        shadowDom: {
+            enabled: process.env.ENABLE_SHADOW_DOM_SUPPORT === 'true',
+            require: './acceptance/plugins/shadow-dom.plugin.js',
+        },
+    },
     /********************** Enable additional plugins as required
      * 
      * plugins: {

--- a/packages/create-codeceptjs-bdd-tests/steps.d.ts
+++ b/packages/create-codeceptjs-bdd-tests/steps.d.ts
@@ -2,12 +2,11 @@
 type ghHomePage = typeof import('./acceptance/pages/github/gh-home.page');
 type ghSearchPage = typeof import('./acceptance/pages/github/gh-search.page');
 type page = typeof import('codeceptjs-configure/lib/helpers/global.page.js');
-type driver_helper = import('./acceptance/helpers/driver.helper');
 type PlaywrightHelper = import('codeceptjs-configure/lib/helpers/playwright.helper.js');
 
 declare namespace CodeceptJS {
   interface SupportObject { I: I, current: any, ghHomePage: ghHomePage, ghSearchPage: ghSearchPage, page: page }
-  interface Methods extends REST, Playwright, driver_helper, PlaywrightHelper {}
+  interface Methods extends REST, Playwright, PlaywrightHelper {}
   interface I extends WithTranslation<Methods> {}
   namespace Translation {
     interface Actions {}


### PR DESCRIPTION
Create framework thru,

```
npx create-codeceptjs-bdd-tests
```

and CLI will ask to add Shadow DOM exclusive support for Webdriver (Playwright has default support)

<img width="1105" alt="Screen Shot 2021-10-13 at 10 57 01 PM" src="https://user-images.githubusercontent.com/3663389/137243107-6531cbf7-0f58-4d74-a872-d26f4912a6b8.png">


