### PR TITLE
Start Playwright With Proxy

### DIFF
--- a/packages/codeceptjs-configure/lib/config/drivers/playwright.conf.js
+++ b/packages/codeceptjs-configure/lib/config/drivers/playwright.conf.js
@@ -48,6 +48,24 @@ const get = function (conf) {
         playwrightConf.helpers.Playwright[CHROMIUM] = { channel: 'chrome' };
     }
 
+    if (process.env.PLAYWRIGHT_BROWSER_PROXY) {
+        console.log('playwrightConf.helpers.Playwright.browser >> ', playwrightConf.helpers.Playwright.browser);
+        console.log('playwrightConf.helpers.Playwright.browser >> ', playwrightConf.helpers.Playwright);
+        let playwrightBrowser = playwrightConf.helpers.Playwright[playwrightConf.helpers.Playwright.browser];
+
+        if (playwrightBrowser) {
+            playwrightConf.helpers.Playwright[playwrightConf.helpers.Playwright.browser].proxy = {
+                server: process.env.PLAYWRIGHT_BROWSER_PROXY,
+            };
+        } else {
+            playwrightConf.helpers.Playwright[playwrightConf.helpers.Playwright.browser] = {
+                proxy: {
+                    server: process.env.PLAYWRIGHT_BROWSER_PROXY,
+                },
+            };
+        }
+    }
+
     conf = merge(conf, playwrightConf);
 
     if (process.env.PLAYWRIGHT_DEVICE) {

--- a/website/docs/03-03-playwright/1-run-with-playwright.md
+++ b/website/docs/03-03-playwright/1-run-with-playwright.md
@@ -115,4 +115,13 @@ To enable this feature, add the below ENV property to the `codecept.env` file,
 RECORD_TRACE_ON_FAIL = true;
 ````
 
+### Start Playwright Browser with Proxy
+
+Set env variable mentioned below, and codecept-bdd will start playwright with proxy,
+
+```js
+PLAYWRIGHT_BROWSER_PROXY = <your-proxy>
+``
+
 More info trace: https://codecept.io/playwright/#trace
+```


### PR DESCRIPTION
set env variable > `PLAYWRIGHT_BROWSER_PROXY=<your-proxy>` and playwright will be launched with Proxy