### PR TITLE
fix(cli): doubled double quotation in scripts

### DIFF
--- a/packages/create-codeceptjs-bdd-tests/cli/update.package.js
+++ b/packages/create-codeceptjs-bdd-tests/cli/update.package.js
@@ -8,8 +8,8 @@ exports.addNpmScripts = (packageJson, RELATIVE_PATH, DRIVER) => {
 
     const SCRIPTS = `"scripts": {
                                     "acceptance": "codeceptjs def && codeceptjs run --steps", 
-                                    "acceptance:parallel": ${parallelScript}",
-                                    "acceptance:parallel:multibrowsers": ${multibrowsersScript}",
+                                    "acceptance:parallel": ${parallelScript},
+                                    "acceptance:parallel:multibrowsers": ${multibrowsersScript},
                                     "acceptance:clean": "allure generate -c -o ./${RELATIVE_PATH}/acceptance/report",
                                     "acceptance:report": "allure serve ./${RELATIVE_PATH}/acceptance/report",`;
 


### PR DESCRIPTION
resolves #85 

As the vars already include the double quotation on https://github.com/salesforce/codeceptjs-bdd/blob/develop/packages/create-codeceptjs-bdd-tests/cli/update.package.js#L6 and https://github.com/salesforce/codeceptjs-bdd/blob/develop/packages/create-codeceptjs-bdd-tests/cli/update.package.js#L7, this leads to the superfluous double quotation in `const SCRIPTS` 